### PR TITLE
FIX: Automatic compile script typo

### DIFF
--- a/examples/compile.sh
+++ b/examples/compile.sh
@@ -15,9 +15,9 @@ make rebuild
 cp LinkCable_stress.gba ../
 cd ..
 
-cd LinkCableMultiboot_demo/
+cd LinkCableMultiBoot_demo/
 make rebuild
-cp LinkCableMultiboot_demo.mb.gba ../
+cp LinkCableMultiBoot_demo.mb.gba ../
 cd ..
 
 cd LinkGPIO_demo/


### PR DESCRIPTION
The automatic compile script doesn't work on the case-sensitive system.